### PR TITLE
patch(docs): update discord chat shield to direct to the invite

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![alt text](Assets/Deckborn.png)
 
-![Discord](https://img.shields.io/discord/714478891602935819?logo=discord&logoColor=white&link=https%3A%2F%2Fdiscord.gg%2FKYgU4zbEZd)
+[![Discord](https://img.shields.io/discord/714478891602935819?logo=discord&logoColor=white)](https://discord.gg/KYgU4zbEZd)
 
 A Skyrim AE modlist built around the Steam Deck!
 


### PR DESCRIPTION
prior to change, the invite link was used as a query parameter with the shield which would have worked if it was used in an `<object>` and not HTML or markup

https://shields.io/badges/discord (decoded entity placeholder for `query`) reads: 
> Specify what clicking on the left/right of a badge should do. Note that this only works when integrating your badge in an &lt;object&gt; HTML tag, but not an &lt;img&gt; tag or a markup language.

*PR description and layout was changed to use the original encoded placeholder text as markup hides the html tags as the markup intends on `shields.io`.*